### PR TITLE
feat: add switch for unknown extension version action

### DIFF
--- a/docs/ChangeLog.txt
+++ b/docs/ChangeLog.txt
@@ -1,3 +1,8 @@
+2022-08-18 Markus Gerdes <mgerdes-atl>
+
+    [FEATURE] add switch to allow unknown extension version numbers
+	[TASK] Raise version to 1.0.0.5-atl
+
 2021-03-22 Michael Schams <schams.net>
 
 	[CLEANUP] Make indentation consistent

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -130,6 +130,19 @@ The following arguments are currently supported as command line options.
        "warning"   generate a warning condition in Nagios
        "critical"  generate a critical condition in Nagios
        Default: warning
+
+  --server-messages-action <action>
+       What should the check script do, if TYPO3 server sends an additional message in
+       the output:
+       "ignore"    do nothing and do not show messages (not recommended)
+       "show"      show messages if they occur (they can be useful)
+       Default: show
+
+  --unknown-extension-version-action <action>
+       One of the following actions, if an enabled deprecation log has been detected:
+       "show"    no condition change, append Version information to message instead
+       "unknown"   generate a unknown condition in Nagios
+       Default: unknown       
 ```
 
 **Deprecated (but still supported) arguments:**


### PR DESCRIPTION
Added an option `--unknown-extension-version-action` [unknown, show].
defaults to unknown for same behaviour as before.
Setting to `show` will return the status to be ok and append the version
string to the nagios message