### PR TITLE
[BUGFIX] Fix parameter validation of --unknown-extension-version-action

### DIFF
--- a/libexec/check_typo3.sh
+++ b/libexec/check_typo3.sh
@@ -560,7 +560,7 @@ while test -n "$1"; do
 			shift
 		;;
 		--unknown-extension-version-action)
-			TEMP=`echo "$2" | egrep "^(show|unknown)$"`
+			TEMP=`echo "$2" | egrep "^(ignore|show|unknown)$"`
 			if [ ! "$TEMP" = "" ]; then
 				UNKNOWN_EXTENSION_VERSION_ACTION="$2"
 			fi


### PR DESCRIPTION
Adds the documented action `ignore` in the parameter check of `--unknown-extension-version-action`.